### PR TITLE
remove app type to allow enabling for groups

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,12 +5,9 @@
 	<description>A Two-Factor-Auth Provider for TOTP (e.g. Google Authenticator) for ownCloud 9.1</description>
 	<licence>AGPL</licence>
 	<author>Christoph Wurst</author>
-	<version>0.2</version>
+	<version>0.2.1</version>
 	<namespace>TwoFactor_Totp</namespace>
 	<category>other</category>
-	<types>
-		<authentication/>
-	</types>
 
 	<two-factor-providers>
 		<provider>OCA\TwoFactor_Totp\Provider\TotpProvider</provider>


### PR DESCRIPTION
Found out that 2FA provider apparently do not need the 'authentication' type, which allows enabling the app for specific groups. Apps are loaded by ``AppManager::getEnabledAppsForUser`` (https://github.com/owncloud/core/pull/24559/files#diff-aadcd6515e9eb96bd55d4cddd2a0c38cR105)

ref https://github.com/owncloud/core/pull/24559#discussion_r64013664

@PVince81 @DeepDiver1975 mind giving this a quick test?