### PR TITLE
switch to more common naming scheme for the TOTP label and its issuer

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -41,23 +41,18 @@ class SettingsController extends Controller {
 	/** @var Defaults */
 	private $defaults;
 
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IUserSession $userSession
 	 * @param ITotp $totp
 	 * @param Defaults $defaults
-	 * @param IURLGenerator $urlGenerator
 	 */
-	public function __construct($appName, IRequest $request, IUserSession $userSession, ITotp $totp, Defaults $defaults, IURLGenerator $urlGenerator) {
+	public function __construct($appName, IRequest $request, IUserSession $userSession, ITotp $totp, Defaults $defaults) {
 		parent::__construct($appName, $request);
 		$this->userSession = $userSession;
 		$this->totp = $totp;
 		$this->defaults = $defaults;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -100,15 +95,24 @@ class SettingsController extends Controller {
 		];
 	}
 
+	/**
+	 * The user's cloud id, e.g. "christina@university.domain/owncloud"
+	 *
+	 * @return string
+	 */
 	private function getSecretName() {
 		$userName = $this->userSession->getUser()->getCloudId();
 		return rawurlencode($userName);
 	}
 
+	/**
+	 * The issuer, e.g. "Nextcloud" or "ownCloud"
+	 *
+	 * @return string
+	 */
 	private function getSecretIssuer() {
 		$productName = $this->defaults->getName();
-		$url = $this->urlGenerator->getAbsoluteURL('/');
-		return rawurlencode("$url ($productName)");
+		return rawurlencode($productName);
 	}
 
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -101,8 +101,9 @@ class SettingsController extends Controller {
 	 * @return string
 	 */
 	private function getSecretName() {
+		$productName = $this->defaults->getName();
 		$userName = $this->userSession->getUser()->getCloudId();
-		return rawurlencode($userName);
+		return rawurlencode("$productName:$userName");
 	}
 
 	/**

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -79,7 +79,7 @@ class SettingsControllerTest extends TestCase {
 
 		$qrCode = new QrCode();
 		$issuer = rawurlencode($this->defaults->getName());
-		$qr = $qrCode->setText("otpauth://totp/user%40instance.com?secret=newsecret&issuer=$issuer")
+		$qr = $qrCode->setText("otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer")
 			->setSize(150)
 			->getDataUri();
 

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -32,7 +32,6 @@ class SettingsControllerTest extends TestCase {
 	private $userSession;
 	private $totp;
 	private $defaults;
-	private $urlGenerator;
 
 	/** @var SettingsController */
 	private $controller;
@@ -44,9 +43,8 @@ class SettingsControllerTest extends TestCase {
 		$this->userSession = $this->getMock('\OCP\IUserSession');
 		$this->totp = $this->getMock('\OCA\TwoFactor_Totp\Service\ITotp');
 		$this->defaults = new Defaults();
-		$this->urlGenerator = $this->getMock('\OCP\IURLGenerator');
 
-		$this->controller = new SettingsController('twofactor_totp', $this->request, $this->userSession, $this->totp, $this->defaults, $this->urlGenerator);
+		$this->controller = new SettingsController('twofactor_totp', $this->request, $this->userSession, $this->totp, $this->defaults);
 	}
 
 	public function testNothing() {
@@ -74,17 +72,13 @@ class SettingsControllerTest extends TestCase {
 		$user->expects($this->once())
 			->method('getCloudId')
 			->will($this->returnValue('user@instance.com'));
-		$this->urlGenerator->expects($this->once())
-			->method('getAbsoluteUrl')
-			->with('/')
-			->will($this->returnValue('https://instance.com'));
 		$this->totp->expects($this->once())
 			->method('createSecret')
 			->with($user)
 			->will($this->returnValue('newsecret'));
 
 		$qrCode = new QrCode();
-		$issuer = rawurlencode('https://instance.com (' . $this->defaults->getName() . ')');
+		$issuer = rawurlencode($this->defaults->getName());
 		$qr = $qrCode->setText("otpauth://totp/user%40instance.com?secret=newsecret&issuer=$issuer")
 			->setSize(150)
 			->getDataUri();


### PR DESCRIPTION
fixes #36

@jas4711 thanks a lot for your feedback. It makes a lot of sense to switch to a more common naming scheme for the TOTP code label and its issuer. Now the issuer is the product name (`Nextcloud`, `ownCloud` or anything customized) and the user's cloud ID is taken as identifier.
Please tell me if this is how you imagined it.

I'd like to release a 0.4.1 once this is in.

cc @DeepDiver1975 